### PR TITLE
modify to enable running in google colab

### DIFF
--- a/dynamic_stac_api/stac_api_demo_workflow.ipynb
+++ b/dynamic_stac_api/stac_api_demo_workflow.ipynb
@@ -48,13 +48,18 @@
     " - [xarray](https://docs.xarray.dev/en/stable/) - work with multidimensional arrays, lazy loading, and parallel processing - great for geospatial raster data\n",
     " - [geopandas](https://geopandas.org/en/stable/index.html) - read item-level metadata and perform attribute queries on item footprints\n",
     "\n",
-    "#### Creating the evnironment to run this notebook\n",
-    "To import the libraries needed to run this notebook, you will need a software environment with them installed. We recommend using the conda (or mamba) environment manager. To build the environment, first install conda or mamba and then run the following command, with the `-f` argument pointing at the `stac_environment.yml` file included next to this notebook in the rgithub repository:\n",
+    "\n",
+    "#### Running this notebook via Google Colab\n",
+    "To run this interactive notebook in the browser, click the `Open in Colab` button at the top of this page. This will open the notebook in Google Colab, a browser-based environment for running notebooks. You will have to run the first code cell to install the necessary packages prior to importing them. You will likely be prompted to authorize the running of the notebook for the first cell since it was not published by Google directly.\n",
+    "\n",
+    "#### Running this notebook locally\n",
+    "##### Creating the evnironment to run this notebook\n",
+    "To import the libraries needed to run this notebook, you will need a software environment with them installed. We recommend using the conda (or mamba) environment manager. To build the environment, first install conda or mamba and then run the following command, with the `-f` argument pointing at the `stac_environment.yml` file included next to this notebook in the github repository:\n",
     "\n",
     "```conda env create -f stac_environment.yml```\n",
     "\n",
-    "#### Running this notebook\n",
-    "Once you have created the conda environment, you can activate the environment in your conda shell with `conda activate pgc-stac-environment`, then run `jupyter notebook`, and navigate to the `stac_api_demo_workflow.ipynb` to launch the notebook. "
+    "##### Launching the notebook\n",
+    "Once you have created the conda environment, you can activate the environment in your conda shell with `conda activate pgc-stac-environment`, then run `jupyter notebook`, and navigate to the `stac_api_demo_workflow.ipynb` to launch the notebook. NOTE: You will not need to run the first cell `pip install ...` if you are running the ntoebook locally with the `pgc-stac-environment` "
    ]
   },
   {
@@ -62,7 +67,10 @@
    "cell_type": "code",
    "outputs": [],
    "execution_count": null,
-   "source": "%pip install pystac-client ipyleaflet stackstac xarray geopandas[all];",
+   "source": [
+    "# Only run this cell when using Google Colab for the notebook\n",
+    "%pip install pystac-client ipyleaflet stackstac xarray geopandas[all];"
+   ],
    "id": "aa182cae95d8e43b"
   },
   {
@@ -114,10 +122,7 @@
      "end_time": "2025-01-07T21:50:11.134772500Z",
      "start_time": "2025-01-07T21:50:10.823422600Z"
     },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [
     {
@@ -1554,10 +1559,7 @@
      "end_time": "2025-01-07T21:50:11.570940900Z",
      "start_time": "2025-01-07T21:50:11.435789500Z"
     },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [
     {
@@ -1594,10 +1596,7 @@
      "end_time": "2025-01-07T21:50:12.855427500Z",
      "start_time": "2025-01-07T21:50:12.724468900Z"
     },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [
     {
@@ -1618,7 +1617,6 @@
       "\n",
       "rema-strips-s2s041-2m\n",
       "REMA time-stamped strip DEMs, s2s version 4.1, 2m resolution\n",
-      "\n",
       "\n"
      ]
     },
@@ -1663,10 +1661,7 @@
      "end_time": "2025-01-07T21:50:13.397378200Z",
      "start_time": "2025-01-07T21:50:13.290934700Z"
     },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [
     {
@@ -4148,10 +4143,7 @@
      "end_time": "2025-01-22T19:43:23.795794600Z",
      "start_time": "2025-01-22T19:43:23.507848300Z"
     },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [
     {
@@ -4176,6 +4168,7 @@
     "m.center = -65.1, -60.2\n",
     "m.zoom = 9\n",
     "m.layout.height = \"600px\"\n",
+    "m.layout.width = \"1000px\"\n",
     "m"
    ]
   },
@@ -4184,10 +4177,7 @@
    "execution_count": 66,
    "id": "44d6ba7d75645538",
    "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [
     {
@@ -4229,7 +4219,7 @@
    "source": [
     "# OR extract the bounding box from a vector file (geojson, shapefile, etc) with geopandas\n",
     "\n",
-    "aoi_shp_fp = \"https://github.com/PolarGeospatialCenter/pgc-code-tutorials/blob/main/dynamic_stac_api/demo_data/demo_aoi_larsen_a_ice_shelf.geojson\"\n",
+    "aoi_shp_fp = \"https://raw.githubusercontent.com/PolarGeospatialCenter/pgc-code-tutorials/main/dynamic_stac_api/demo_data/demo_aoi_larsen_a_ice_shelf.geojson\"\n",
     "aoi_gdf = gpd.read_file(aoi_shp_fp)\n",
     "aoi_bbox = aoi_gdf.total_bounds\n",
     "print(aoi_bbox)"

--- a/dynamic_stac_api/stac_api_demo_workflow.ipynb
+++ b/dynamic_stac_api/stac_api_demo_workflow.ipynb
@@ -1,6 +1,12 @@
 {
  "cells": [
   {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PolarGeospatialCenter/pgc-code-tutorials/blob/main/dynamic_stac_api/stac_api_demo_workflow.ipynb)",
+   "id": "1547d09cf4b110f6"
+  },
+  {
    "cell_type": "markdown",
    "id": "c19efdd5-00f1-4fc8-90f4-f93b78490ba6",
    "metadata": {},
@@ -50,6 +56,14 @@
     "#### Running this notebook\n",
     "Once you have created the conda environment, you can activate the environment in your conda shell with `conda activate pgc-stac-environment`, then run `jupyter notebook`, and navigate to the `stac_api_demo_workflow.ipynb` to launch the notebook. "
    ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "%pip install pystac-client ipyleaflet stackstac xarray geopandas[all];",
+   "id": "aa182cae95d8e43b"
   },
   {
    "cell_type": "code",
@@ -4215,7 +4229,7 @@
    "source": [
     "# OR extract the bounding box from a vector file (geojson, shapefile, etc) with geopandas\n",
     "\n",
-    "aoi_shp_fp = \"demo_data/demo_aoi_larsen_a_ice_shelf.geojson\"\n",
+    "aoi_shp_fp = \"https://github.com/PolarGeospatialCenter/pgc-code-tutorials/blob/main/dynamic_stac_api/demo_data/demo_aoi_larsen_a_ice_shelf.geojson\"\n",
     "aoi_gdf = gpd.read_file(aoi_shp_fp)\n",
     "aoi_bbox = aoi_gdf.total_bounds\n",
     "print(aoi_bbox)"


### PR DESCRIPTION
This PR adds two cells and modifies an existing cell.

1. Added "Open In Colab" button to the top of the notebook. This button will not work until the repository is public.
3. Added a `%pip` cell to install the required libraries into the runtime. If this is run in an environment that already has these libraries, such as one built with the provided `stac_environment.yml`, it should have no effect.
4. Changed the path to the demo aoi to its full GitHub url. Like item one, this will not work until the repository is public.

You can test the `%pip` part by cloning this PR and then uploading the notebook directly to Google Colab via their web interface. All the cells, except for the one noted in item 3 above should work as usual. 